### PR TITLE
Add dockerfile for easier local deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ files/*
 .sass-cache
 static/css/*
 !static/css/.keep
+
+# Exclude flask config file as it contains secret keys
+instance/config.py

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,3 @@ files/*
 .sass-cache
 static/css/*
 !static/css/.keep
-
-# Exclude flask config file as it contains secret keys
-instance/config.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,6 +18,8 @@ RUN apt-get update -y --fix-missing && \
   pip install wheel
 COPY --from=builder /app /app
 WORKDIR /app
-RUN pip install -r requirements.txt
+RUN pip install -r requirements.txt && \
+  mkdir -p /data/db && \
+  mkdir instance
 EXPOSE 5000
 CMD ["./docker-start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:latest
+MAINTAINER Shikher Verma "root@shikherverma.com"
+RUN apt-get update -y --fix-missing
+RUN apt-get install -y python python-pip python-dev build-essential git nodejs npm ruby ruby-dev
+# Install Dependencies
+RUN \
+  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10 && \
+  echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' > /etc/apt/sources.list.d/mongodb.list && \
+  apt-get update && \
+  apt-get install -y mongodb-org && \
+  rm -rf /var/lib/apt/lists/*
+COPY . /app
+WORKDIR /app
+RUN pip install -r requirements.txt
+RUN npm install --verbose
+RUN gem install sass
+EXPOSE 5000
+CMD ["./docker-start.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,23 @@
-FROM ubuntu:latest
-MAINTAINER Shikher Verma "root@shikherverma.com"
-RUN apt-get update -y --fix-missing
-RUN apt-get install -y python python-pip python-dev build-essential git nodejs npm ruby ruby-dev
-# Install Dependencies
-RUN \
-  apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 7F0CEB10 && \
-  echo 'deb http://downloads-distro.mongodb.org/repo/ubuntu-upstart dist 10gen' > /etc/apt/sources.list.d/mongodb.list && \
-  apt-get update && \
-  apt-get install -y mongodb-org && \
-  rm -rf /var/lib/apt/lists/*
+FROM debian:stable-slim as builder
+LABEL maintainer "root@shikherverma.com"
+RUN apt-get update -y --fix-missing && \
+  apt-get install -y --no-install-recommends ruby ruby-dev build-essential gnupg2 dirmngr curl && \
+  gem install sass && \
+  curl -sL https://deb.nodesource.com/setup_8.x | bash - && \
+  apt-get install -y --no-install-recommends nodejs && \
+  npm install -g gulp
 COPY . /app
 WORKDIR /app
+RUN npm install && \
+  sass static/scss/main.scss:static/css/main.scss.css -E "UTF-8" && \
+  gulp
+
+FROM debian:stable-slim
+RUN apt-get update -y --fix-missing && \
+  apt-get install -y --no-install-recommends python python-pip python-dev python-setuptools build-essential git mongodb && \
+  pip install wheel
+COPY --from=builder /app /app
+WORKDIR /app
 RUN pip install -r requirements.txt
-RUN npm install --verbose
-RUN gem install sass
 EXPOSE 5000
 CMD ["./docker-start.sh"]

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
 
-mkdir -p /data/db
 mongod &
-mkdir instance
 echo 'DEBUG=False' >> instance/config.py
 echo "SECRET_KEY='?\xbf,\xb4\x8d\xa3<\x9c\xb0@\x0f5\xab,w\xee\x8d$0\x13\x8b83'" >> instance/config.py
 python wizard.py

--- a/docker-start.sh
+++ b/docker-start.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+mkdir -p /data/db
+mongod &
+mkdir instance
+echo 'DEBUG=False' >> instance/config.py
+echo "SECRET_KEY='?\xbf,\xb4\x8d\xa3<\x9c\xb0@\x0f5\xab,w\xee\x8d$0\x13\x8b83'" >> instance/config.py
+python wizard.py


### PR DESCRIPTION
Fixes #11 

Build image from docker file using
```
docker build -t="python-flask" .
```

Run
```
docker run --net=host -d python-flask
```

Notes : On arch linux I had to run it with `--net=host` for port mapping to work. Might not be needed for other distros.