### PR TITLE
Update to in-toto 0.1.1

### DIFF
--- a/create_layout.py
+++ b/create_layout.py
@@ -90,6 +90,7 @@
 import os
 import in_toto.models.link
 import in_toto.models.layout
+import in_toto.models.metdata
 
 def create_material_matchrules(links, index):
   """Create generic material rules (3 variants)
@@ -151,4 +152,6 @@ def create_layout_from_ordered_links(links):
 
     layout.steps.append(step)
 
-  return layout
+  layout_metadata = in_toto.models.metadata.Metablock(signed=layout)
+
+  return layout_metadata

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Flask
 Flask-PyMongo
 Flask-WTF
--e git://github.com/in-toto/in-toto.git@c39b04cec329bead34232a39742ebda5947633fd#egg=in-toto
+in-toto==0.1.1

--- a/templates/chaining.html
+++ b/templates/chaining.html
@@ -47,7 +47,7 @@
 {%- for step in steps %}
 in-toto-mock --name {{step.name}} -- {{step.cmd}}
 {%- endfor %}
-tar czf in_toto_link_files.tar.gz {% for step in steps%}{{step.name}}.link-mock {% endfor %}
+tar czf in_toto_link_files.tar.gz {% for step in steps%}{{step.name}}.link {% endfor %}
 </pre>
   </div>
   {#- END: Mock run command snippet  -#}


### PR DESCRIPTION
This version of in-toto uses a new metadata format, where links and layouts are embedded in a Metablock's "signed" field, the Metablock also contains a signature field that can carry signatures over the contents of the signed field.

This PR updates:
- requirements.txt to install in-toto from pypi at 0.1.1
- the link loading calls (to handle the new metadata format)
- the layout dumping call (to handle the new metadata format)