### PR TITLE
Update to in-toto 0.1.1 (fixing earlier PR)

### DIFF
--- a/create_layout.py
+++ b/create_layout.py
@@ -151,4 +151,5 @@ def create_layout_from_ordered_links(links):
 
     layout.steps.append(step)
 
+
   return layout

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Flask
 Flask-PyMongo
 Flask-WTF
--e git://github.com/in-toto/in-toto.git@c39b04cec329bead34232a39742ebda5947633fd#egg=in-toto
+in-toto==0.1.1

--- a/templates/chaining.html
+++ b/templates/chaining.html
@@ -47,7 +47,7 @@
 {%- for step in steps %}
 in-toto-mock --name {{step.name}} -- {{step.cmd}}
 {%- endfor %}
-tar czf in_toto_link_files.tar.gz {% for step in steps%}{{step.name}}.link-mock {% endfor %}
+tar czf in_toto_link_files.tar.gz {% for step in steps%}{{step.name}}.link {% endfor %}
 </pre>
   </div>
   {#- END: Mock run command snippet  -#}

--- a/templates/start.html
+++ b/templates/start.html
@@ -29,7 +29,7 @@ Secure your software with in-toto
 <p>You will be asked to run a couple of in-toto commands while walking through this website, so make sure to have in-toto installed:</p>
 
 <pre class="code">
-pip install git+git://github.com/in-toto/in-toto.git
+pip install in-toto==0.1.1
 </pre>
 
 <hr>


### PR DESCRIPTION
Contains fixes for #35 

This version of in-toto uses a new metadata format, where links and layouts are embedded in a Metablock's "signed" field, the Metablock also contains a signature field that can carry signatures over the contents of the signed field.

This PR updates
- requirements.txt to install in-toto from pypi at 0.1.1
- the link loading calls (to handle the new metadata format)
- the layout dumping call (to handle the new metadata format)
- the installation instruction on start page

Also fixes an import that was broken after a module rename.