### PR TITLE
Create before_after_filesystem_snapshot.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+language: python
+python:
+  - "3.8"
+cache: pip
+install:
+  - pip install -r requirements.txt
+script:
+  python -m unittest tests.test_before_after_filesystem_snapshot

--- a/before_after_filesystem_snapshot.py
+++ b/before_after_filesystem_snapshot.py
@@ -25,3 +25,40 @@ def snapshot(before_dict, after_dict):
   # Returning the snapshot of the new file system
   return (sorted(unchanged_files), sorted(modified_files), sorted(added_files),
   sorted(removed_files))
+
+def generate_artifact_rules(snapshot):
+  '''
+  Generate Artifact Rules given which files have been added, which have been
+  removed, which have been modified, and which have remained unchanged.
+  '''
+  expected_materials = []
+  expected_products = []
+
+  # TODO: missing rules for MATCH since we don't have the information of the
+  # material from the previous step
+  for file in snapshot[0]:
+    # unchanged files
+    expected_materials.append(["ALLOW", file])
+  for file in snapshot[1]:
+    # modified files
+    expected_materials.append(["ALLOW", file])
+  for file in snapshot[3]:
+    # removed files
+    expected_materials.append(["DELETE", file])
+  expected_materials.append(["DISALLOW", "*"])
+
+  for file in snapshot[0]:
+    # unchanged files
+    expected_products.append(["ALLOW", file])
+  for file in snapshot[1]:
+    # modified files
+    expected_products.append(["MODIFY", file])
+  for file in snapshot[2]:
+    # added files
+    expected_products.append(["CREATE", file])
+  expected_products.append(["DISALLOW", "*"])
+
+  return {
+    'expected_materials': expected_materials,
+    'expected_products': expected_products
+  }

--- a/before_after_filesystem_snapshot.py
+++ b/before_after_filesystem_snapshot.py
@@ -1,0 +1,27 @@
+def snapshot(before_dict, after_dict):
+  '''before_after_snapshot is a simple function that returns which files were
+    unchanged, modified, added or removed from an input dictionary (before_dict)
+    and an output dictionary (after_dict). Both these dictionaries have file
+    names as the keys and their hashes as the values.'''
+
+  unchanged_files = []
+  modified_files = []
+  added_files = []
+  removed_files = []
+  for key in before_dict:
+    if key in after_dict:
+      if before_dict[key] == after_dict[key]:
+        # Matching the hashes to check if file was unchanged
+        unchanged_files.append(key)
+      else:
+        modified_files.append(key)
+    else:
+      removed_files.append(key)
+  for key in after_dict:
+    if key not in before_dict:
+      # Looking for new files
+      added_files.append(key)
+
+  # Returning the snapshot of the new file system
+  return (sorted(unchanged_files), sorted(modified_files), sorted(added_files),
+  sorted(removed_files))

--- a/tests/test_before_after_filesystem_snapshot.py
+++ b/tests/test_before_after_filesystem_snapshot.py
@@ -1,0 +1,113 @@
+import unittest
+import before_after_filesystem_snapshot
+
+class Test_before_after_filesystem_snapshot(unittest.TestCase):
+
+  '''Check whether the output of before_after_filesystem_snapshot is as defined
+    by each test case.'''
+
+  before = {
+    'one.tgz': '1234567890abcdef',
+    'foo/two.tgz': '0000001111112222',
+    'three.txt': '1111222233334444',
+    'bar/bat/four.tgz': '6677889900112233'
+  }
+
+  def test_same_filesystem_snapshot(self):
+
+    after = {
+      'one.tgz': '1234567890abcdef',
+      'foo/two.tgz': '0000001111112222',
+      'three.txt': '1111222233334444',
+      'bar/bat/four.tgz': '6677889900112233'
+    }
+
+    snapshot = before_after_filesystem_snapshot.snapshot(self.before, after)
+    self.assertEqual(snapshot, (['bar/bat/four.tgz', 'foo/two.tgz', 'one.tgz',
+      'three.txt'], [], [], []))
+
+
+  def test_removed_files_filesystem_snapshot(self):
+
+    after = {}
+
+    snapshot = before_after_filesystem_snapshot.snapshot(self.before, after)
+    self.assertEqual(snapshot, ([], [], [], ['bar/bat/four.tgz', 'foo/two.tgz',
+      'one.tgz', 'three.txt']))
+
+
+  def test_new_filesystem_snapshot(self):
+    after = {
+      'five.tgz': '1234567890defghi',
+      'foo/bar/six.tgz': '0000001111112234',
+      'foofoo/seven.txt': '1111222233334555'
+    }
+
+    snapshot = before_after_filesystem_snapshot.snapshot(self.before, after)
+    self.assertEqual(snapshot, ([], [], ['five.tgz', 'foo/bar/six.tgz',
+      'foofoo/seven.txt'], ['bar/bat/four.tgz', 'foo/two.tgz', 'one.tgz',
+      'three.txt']))
+
+
+  def test_fully_modified_filesystem_snapshot(self):
+
+    after = {
+      'one.tgz': '1234567890aabbcc',
+      'foo/two.tgz': '0000001111112233',
+      'three.txt': '1111222233334455',
+      'bar/bat/four.tgz': '6677889900123456'
+    }
+
+    snapshot = before_after_filesystem_snapshot.snapshot(self.before, after)
+    self.assertEqual(snapshot, ([], ['bar/bat/four.tgz', 'foo/two.tgz',
+      'one.tgz', 'three.txt'], [], []))
+
+
+  def test_partially_modified_filesystem_snapshot(self):
+
+    after = {
+      'five.txt': '5555555555555555',
+      'one.tgz': '1234567890abcdef',
+      'foo/two.tgz': 'ffffffffffffffff',
+      'bar/bat/four.tgz': '6677889900123456',
+      'baz/six.tgz': '6666666666666666'
+    }
+
+    snapshot = before_after_filesystem_snapshot.snapshot(self.before, after)
+    self.assertEqual(snapshot, (['one.tgz'], ['bar/bat/four.tgz',
+      'foo/two.tgz'], ['baz/six.tgz', 'five.txt'], ['three.txt']))
+
+  def test_generate_artifact_rules(self):
+
+    after = {
+      'five.txt': '5555555555555555',
+      'one.tgz': '1234567890abcdef',
+      'foo/two.tgz': 'ffffffffffffffff',
+      'bar/bat/four.tgz': '6677889900112233',
+      'baz/six.tgz': '6666666666666666'
+    }
+
+    artifact_rules = {
+      'expected_materials': [
+        ['ALLOW', 'bar/bat/four.tgz'],
+        ['ALLOW', 'one.tgz'],
+        ['ALLOW', 'foo/two.tgz'],
+        ['DELETE', 'three.txt'],
+        ['DISALLOW', '*']
+      ],
+      'expected_products': [
+        ['ALLOW', 'bar/bat/four.tgz'],
+        ['ALLOW', 'one.tgz'],
+        ['MODIFY', 'foo/two.tgz'],
+        ['CREATE', 'baz/six.tgz'],
+        ['CREATE', 'five.txt'],
+        ['DISALLOW', '*']
+      ]
+    }
+
+    snapshot = before_after_filesystem_snapshot.snapshot(self.before, after)
+    rules = before_after_filesystem_snapshot.generate_artifact_rules(snapshot)
+    self.assertDictEqual(artifact_rules, rules)
+
+  if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR aims to resolve a sub-task of Issue #6 by introducing a WIP feature to the layout-web-tool which has 2 functions, corresponding tests and sets up Travis for this repository. The first function 'snapshot' returns which files were unchanged, modified, added, or removed from an input dictionary (before_dict) and an output dictionary (after_dict). The second function 'generate_artifact_rules' generates artifact rules for the previous function.