### PR TITLE
Decode functionary_key.read() to ASCII

### DIFF
--- a/wizard.py
+++ b/wizard.py
@@ -655,7 +655,7 @@ def ajax_upload_key():
   try:
     # We try to load the public key to check the format
     key = securesystemslib.keys.import_rsakey_from_public_pem(
-        functionary_key.read())
+        functionary_key.read().decode("ascii"))
 
     securesystemslib.formats.PUBLIC_KEY_SCHEMA.check_match(key)
     file_name = functionary_key.filename
@@ -700,6 +700,10 @@ def ajax_upload_key():
           "alert-success")
 
     # TODO: Throw more rocks at query_result
+
+  except UnicodeDecodeError:
+    flash("Could not decode the key. The key contains non-ascii characters.")
+    return jsonify({"error": True})
 
   except Exception as e:
     flash("Could not store uploaded file. Error: {}".format(e),


### PR DESCRIPTION
In python3, read() return bytes rather than string. This will cause problems when we upload and store the functionary key, as we expect a string object instead. 

Here is a reference to the python3 [document](ajax_upload_key) :
> As mentioned in the Overview, Python distinguishes between binary and text I/O. Files opened in binary mode (including 'b' in the mode argument) return contents as bytes objects without any decoding. In text mode (the default, or when 't' is included in the mode argument), the contents of the file are returned as str, the bytes having been first decoded using a platform-dependent encoding or using the specified encoding if given.
