### PR TITLE
Remove duplicate PROJECT-OWNER from wrap_up sign command

### DIFF
--- a/templates/wrap_up.html
+++ b/templates/wrap_up.html
@@ -39,7 +39,7 @@
   <div>
 <pre class="code">
 in-toto-keygen &ltPROJECT-OWNER&gt
-in-toto-sign --key &ltPROJECT-OWNER&gt --file &ltPROJECT-OWNER&gt &ltYOUR LAYOUT&gt.layout
+in-toto-sign --key &ltPROJECT-OWNER&gt --file &ltYOUR LAYOUT&gt.layout
 </pre>
   </div>
   {#- END: Key/Sign layout snippet -#}


### PR DESCRIPTION
Before:

```console
$ in-toto-sign --key ~/alice --file ~/alice httptest.layout
usage: in-toto-sign [-h] -f <path> [-k <path> [<path> ...]] [-t {rsa,ed25519,ecdsa} [{rsa,ed25519,ecdsa} ...]] [-p]
                    [-g [<id> ...]] [--gpg-home <path>] [-o <path>] [-a] [--verify] [-v | -q] [--version]
in-toto-sign: error: unrecognized arguments: httptest.layout
$ echo $?
2
```

After:

```console
$ in-toto-sign --key ~/alice --file httptest.layout
$ echo $?
0
```

Great tool, thank you!